### PR TITLE
BDOG-2238 Fix root module folder name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .metals/
 .vscode/
 .bloop/
+.bsp/
 project/metals.sbt
 logs
 project/project

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Writes some project information in yaml format to the file specified by the envi
 
 ### Sbt 1.x
 
-This plugin is cross compiled for sbt `0.13.18` and `1.3.4`
+This plugin is compiled for sbt `1.x`
 
 
 ### Tests

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ lazy val project = Project("sbt-build-jobs", file("."))
   .settings(
     majorVersion := 0,
     isPublicArtefact := true,
-    crossSbtVersions := Vector("0.13.18", "1.3.4"),
-    scalaVersion := "2.12.15",
+    crossSbtVersions := Vector("1.6.2"),
+    scalaVersion := "2.12.17",
     addSbtPlugin("uk.gov.hmrc"  % "sbt-setting-keys" % "0.3.0" ),
     resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns),
     scriptedLaunchOpts := { scriptedLaunchOpts.value ++

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.8.0")

--- a/src/sbt-test/sbt-build-jobs/writeMeta-multimodule/build.sbt
+++ b/src/sbt-test/sbt-build-jobs/writeMeta-multimodule/build.sbt
@@ -1,3 +1,5 @@
+lazy val root = (project in file(".")).aggregate(myProject1, myProject2)
+
 lazy val myProject1 = (project in file("my-project-1"))
   .settings(
     organization       := "uk.gov.hmrc",
@@ -62,8 +64,8 @@ lazy val myProject3 = (project in file("my-project-3"))
 
 TaskKey[Unit]("check") := {
   val expectedContent =
-    """|name              : "writemeta-multimodule"
-       |organization      : "default"
+    """|name              : "root"
+       |organization      : "root"
        |version           : "0.1.0-SNAPSHOT"
        |sbtVersion        : "1.4.9"
        |crossScalaVersions: ["2.12.12"]

--- a/src/sbt-test/sbt-build-jobs/writeProjects-multimodule/build.sbt
+++ b/src/sbt-test/sbt-build-jobs/writeProjects-multimodule/build.sbt
@@ -3,8 +3,10 @@ val expectedContent =
      |  folder: my-project-1
      |- module: myProject2
      |  folder: my-project-2
-     |- module: writeprojects-multimodule
-     |  folder: writeProjects-multimodule""".stripMargin
+     |- module: root
+     |  folder: root""".stripMargin
+
+lazy val root = (project in file(".")).aggregate(myProject1, myProject2)
 
 lazy val myProject1 = (project in file("my-project-1"))
 

--- a/src/sbt-test/sbt-build-jobs/writeProjects/build.sbt
+++ b/src/sbt-test/sbt-build-jobs/writeProjects/build.sbt
@@ -1,6 +1,6 @@
 val expectedContent =
   """|- module: root
-     |  folder: writeProjects""".stripMargin
+     |  folder: root""".stripMargin
 
 lazy val root = (project in file("."))
   .settings(


### PR DESCRIPTION
Since the folder the project is checked out into may not match the repo name.

Also bumped sbt version which has influenced the default module name and organisation and affected tests - use of the default is not expected (nor matters) for real.